### PR TITLE
Moves the "special thanks to X codebases" to the top of the changelog

### DIFF
--- a/html/changelog.html
+++ b/html/changelog.html
@@ -45,6 +45,9 @@
 		</td>
 	</tr>
 </table>
+<div class='test2	'>
+<b><center><font color="black">Special thanks to: OpenSS13 Developers, GoonStation 13 Development Team, /TG/ Station 13 developers, Baystation 12 developers, Facepunch Station 13 developers, VG Station 13 developers, Unbound Travels developers, Atlas Station developers, and players like you!</font></center></b>
+</div>
 <p>
 <!-- NOTE TO UPDATERS!! Please only list things which are important to players.
 Stuff which is in development and not yet visible to players or just code related
@@ -1512,10 +1515,6 @@ should be listed in the changelog upon commit tho. Thanks. -->
 	</ul>
 </div>
 
-
-<div class='test2	'>
-<b><center><font color="black">Special thanks to: GoonStation 13 Development Team, /TG/ Station coders, Unbound Travels coders, Facepunch Station 13 coders, vgstation13, AtlasStation and players like you!</font></center></b>
-</div>
 
 <br>
 <center>


### PR DESCRIPTION
This way my OCD is satisfied and the contributor list is all in 1 nice place. I also reorganized them in order of age, from oldest to youngest.

Picture SOON :tm:

Also, I added OpenSS13 to the list, along with Baystation 12. TG, which you're forked from, has borrowed so much bs12 code it's not even funny. Also, literally none of the current codebases would exist without OpenSS13, because what would 4407 been branched off of if OpenSS13 didn't exist?

Why was it even at the bottom?

PSA: Let's keep this PR free of drama.