### PR TITLE
Proxy Buster

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -39,7 +39,7 @@
 	var/Ticklag = 0.9
 	var/Tickcomp = 0
 	var/allow_holidays = 0				//toggles whether holiday-specific content should be used
-
+	var/proxybuster = 0 //For using the proxybuster
 	var/hostedby = null
 	var/respawn = 1
 	var/guest_jobban = 1
@@ -268,6 +268,8 @@
 					guests_allowed = 0
 				if("usewhitelist")
 					config.usewhitelist = 1
+				if("proxybuster")
+					config.proxybuster = 1
 				if("allow_metadata")
 					config.allow_Metadata = 1
 				if("kick_inactive")

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -47,7 +47,7 @@
 /obj/item/weapon/storage/backpack/holding/handle_item_insertion(obj/item/W, prevent_warning = 0, mob/user)
 	if(istype(W, /obj/item/weapon/storage/backpack/holding) && !W.crit_fail)
 		var/safety = alert(user, "You feel this may not be the best idea.", "Put in [name]?", "Proceed", "Abort")
-		if(safety == "Abort" || !in_range(src, user) || !src || !W || user.incapacitated())
+		if(safety == "Abort" || !in_range(src, user) || !src || !W || user.restrained() || user.stat || user.weakened || user.stunned || user.paralysis || user.lying)
 			return
 		investigate_log("has become a singularity. Caused by [user.key]","singulo")
 		user << "<span class='danger'>The Bluespace interfaces of the two devices catastrophically malfunction!</span>"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,4 +1,12 @@
 //handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
+var/list/proxyvpnblocker = file2list("config/buster.txt")
+var/list/proxyvpnblockerlist = list()
+var/dummything = list()
+//Alright what the above does marks people who are using a recorded proxy/vpn's IP address.
+//Setup for people without databases. Database version eventually.
+//All IPs must be set through config/buster.txt
+//http://i.imgur.com/u6UBNlH.png
+
 /mob/proc/update_Login_details()
 	//Multikey checks and logging
 	lastKnownIP	= client.address
@@ -23,6 +31,14 @@
 						message_admins("<font color='red'><B>Notice: </B><font color='blue'>[key_name_admin(src)] has the same [matches] as [key_name_admin(M)] (no longer logged in). </font>")
 						log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
 
+	if(config.proxybuster)
+		if(client in proxyvpnblockerlist)//Already in the list
+			return
+		if(lastKnownIP in proxyvpnblocker)
+			message_admins("<font color='red'><B>Notice: </B><font color='blue'>[key_name_admin(src)] is using an IP address ([lastKnownIP]) associated with VPN/Proxy on the watchlist.</font>")
+			log_access("[key_name_admin(src)] is using an IP address ([lastKnownIP]) associated with VPN/Proxy on the watchlist.")
+			proxyvpnblockerlist.Add(proxyvpnblockerlist)
+			dummything += "[key_name_admin(src)] is using an IP address ([lastKnownIP]) associated with VPN/Proxy on the watchlist."
 /mob/Login()
 	player_list |= src
 	update_Login_details()

--- a/config/buster.txt
+++ b/config/buster.txt
@@ -1,0 +1,7 @@
+###############################################################################################
+# VPS/Proxy IPs go here. Only for those. This isn't for banning                               #
+#                                                                                             #
+# One line per IP.                                                                            #
+# In-game will alert admins when they connect for the first time in the round                 #
+# Reports to end round logs for a condensed view.		                              #
+###############################################################################################

--- a/config/config.txt
+++ b/config/config.txt
@@ -159,3 +159,6 @@ ACHIEVEMENT_HUB
 ACHIEVEMENT_PASSWORD 
 
 ##Why do you guys keep reuploading this with the hub stuff still set.
+
+##Proxybuster. # for off. Add IPs to buster.txt
+#PROXYBUSTER


### PR DESCRIPTION
Use buster.txt to add IP addresses for public VPN and Proxy IP
addresses. One line per IP.

Alerts admins and logs into the serverlogs. Does not alert users that
they are using a known one, only admins.  This does not ban them, as
someone may legitly be using a VPN/Proxy

At most this just points out people using it. Much like if you have two
people in the same house on two different computers playing.  Only
useful for people using said IPs, but may or may not be useful for
someone running a virtualbox and grabbing a random public IP for sites.
Consider this more of an early warning system. Though it has it flaws,
only IPs entered will be ones it checks. More robust system to come.

Note: THIS DOES NOT BAN THEM.